### PR TITLE
Refactor word_multiplier from list to set for faster membership testing

### DIFF
--- a/vietnam_number/word2number/data.py
+++ b/vietnam_number/word2number/data.py
@@ -16,14 +16,14 @@ units = {
     'chín': 9,
 }
 
-billion_words = ['tỷ', 'tỏi', 'tỉ']
-million_words = ['triệu', 'củ', 'chai']
-thousand_words = ['nghìn', 'nghàn', 'ngàn']
+billion_words = ("tỷ", "tỏi", "tỉ")
+million_words = ("triệu", "củ", "chai")
+thousand_words = ("nghìn", "nghàn", "ngàn")
 
-hundreds_words = ['trăm', 'lít']
-tens_words = ['mươi', 'chục']
+hundreds_words = ("trăm", "lít")
+tens_words = ("mươi", "chục")
 
-tens_special = ['mười']
-special_word = ['lẽ', 'linh', 'lẻ']
+tens_special = ("mười",)
+special_word = ("lẽ", "linh", "lẻ")
 
 word_multiplier = billion_words + million_words + thousand_words + hundreds_words + tens_words + tens_special + special_word

--- a/vietnam_number/word2number/data.py
+++ b/vietnam_number/word2number/data.py
@@ -26,4 +26,12 @@ tens_words = ("mươi", "chục")
 tens_special = ("mười",)
 special_word = ("lẽ", "linh", "lẻ")
 
-word_multiplier = billion_words + million_words + thousand_words + hundreds_words + tens_words + tens_special + special_word
+word_multiplier = set().union(
+    billion_words,
+    million_words,
+    thousand_words,
+    hundreds_words,
+    tens_words,
+    tens_special,
+    special_word,
+)


### PR DESCRIPTION
**Description:**
This PR changes `word_multiplier` from a **list** to a **set** and converts the original word groups to **tuples**. The main goal is to improve performance during membership checks (`word in word_multiplier`) and avoid inefficiencies in list concatenation.

### Key Points:

* **Avoid quadratic cost of list concatenation:**

  ```python
  list1 + list2 + list3 + ...
  ```

  Each `+` copies all previous elements, resulting in **O(n²)** in the worst case.

* **Set construction is linear:**

  ```python
  word_multiplier = set()
  word_multiplier.union(list1, list2, ...)
  ```

  * Build: **O(n)**, each element added once
  * Membership test: **O(1)** per lookup

* **Tuples are faster and safer than lists:**

  * Creating tuples is **slightly faster** than creating lists.
  * Tuples are immutable, preventing accidental modification of word groups.

* **Other benefits:**

  * Scales efficiently for larger word lists
  * Functionality remains unchanged

### Example:

```python
# Before (list, O(n) lookup)
if word in word_multiplier:
    ...

# After (set, O(1) lookup)
if word in word_multiplier:
    ...
```

**Result:** More efficient, maintainable, and scalable code.
