### PR TITLE
Refactor code to leverage Python string methods

### DIFF
--- a/vietnam_number/number2word/__init__.py
+++ b/vietnam_number/number2word/__init__.py
@@ -12,7 +12,7 @@ def n2w(number: str):
 
 def n2w_single(number: str):
     # Xữ lý đặc thù dành cho số điện thoại
-    if number[0:3] == '+84':
+    if number.startswith("+84"):
         number = number.replace('+84', '0')
 
     # Tiền xữ lý dữ liệu chuỗi số đầu vào

--- a/vietnam_number/number2word/__init__.py
+++ b/vietnam_number/number2word/__init__.py
@@ -13,7 +13,7 @@ def n2w(number: str):
 def n2w_single(number: str):
     # Xữ lý đặc thù dành cho số điện thoại
     if number.startswith("+84"):
-        number = number.replace('+84', '0')
+        number = number.replace("+84", "0", count=1)
 
     # Tiền xữ lý dữ liệu chuỗi số đầu vào
     clean_number = pre_process_n2w(number)

--- a/vietnam_number/number2word/single.py
+++ b/vietnam_number/number2word/single.py
@@ -10,11 +10,7 @@ def process_n2w_single(numbers: str):
     Returns:
         Chuỗi chữ số đầu ra.
     """
-    total_number = ''
-    for element in numbers:
-        total_number += units[element] + ' '
-
-    return total_number.strip()
+    return " ".join(units[element] for element in numbers)
 
 
 if __name__ == '__main__':

--- a/vietnam_number/number2word/utils/base.py
+++ b/vietnam_number/number2word/utils/base.py
@@ -1,5 +1,12 @@
 from vietnam_number.number2word.data import units
 
+CHAR_TO_REMOVE = {
+    " ": None,
+    "-": None,
+    ".": None,
+    ",": None,
+}
+TRANS_TABLE = str.maketrans(CHAR_TO_REMOVE)
 
 def chunks(lst, n):
     """Hàm chia nhỏ danh sách đầu vào.
@@ -30,18 +37,9 @@ def pre_process_n2w(number: str):
     Returns:
         Chuỗi số sau khi được tiền xữ lý.
     """
-    clean_number = ''
-
-    char_to_replace = {
-        ' ': '',
-        '-': '',
-        '.': '',
-        ',': '',
-    }
 
     # xóa các ký tự đặt biệt
-    for key, value in char_to_replace.items():
-        number = number.replace(key, value)
+    number = number.translate(TRANS_TABLE)
 
     # Kiểm tra tính hợp lệ của đầu vào
     if not number.isdigit():


### PR DESCRIPTION
This PR refactors parts of the code to consistently use Python’s built-in string methods (`startswith`, `join`, `translate`) instead of manual loops, slicing, and repeated `replace()` calls.

#### **Key Improvements**

1. **Prefix Handling**:

   * Replaced slicing (`number[0:3] == '+84'`) with `startswith("+84")` and used `replace(..., count=1)` to safely update only the prefix.

2. **String Assembly**:

   * Replaced manual concatenation in loops with `" ".join(...)`, improving efficiency and readability.

3. **Character Removal**:

   * Replaced repetitive `replace()` calls with a single `str.translate()`.

#### **Benefits**

* **Cleaner**: The code now clearly expresses intent.
* **Improved Performance**: Built-in string methods are faster than repeated Python-level operations.

