### PR TITLE
Update python requirement to version 3.8 and use @cached_property to improve performance

### DIFF
--- a/vietnam_number/__init__.py
+++ b/vietnam_number/__init__.py
@@ -3,8 +3,8 @@ import sys
 # Check python version
 try:
     version_info = sys.version_info
-    if version_info < (3, 6, 0):
-        raise RuntimeError("vietnam-number requires Python 3.6 or later")
+    if version_info < (3, 8, 0):
+        raise RuntimeError("vietnam-number requires Python 3.8 or later")
 except Exception:
     pass
 

--- a/vietnam_number/word2number/utils/base.py
+++ b/vietnam_number/word2number/utils/base.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 from vietnam_number.word2number.data import (
     billion_words,
     hundreds_words,
@@ -22,7 +24,7 @@ class Numbers(object):
         """
         self.words_number = words_number
 
-    @property
+    @cached_property
     def get_keyword_index(self):
         """Lấy vị trí index của các từ khóa như mười, trăm, nghìn, triệu, tỷ.
 


### PR DESCRIPTION
### Refactor: Use `@cached_property` for `get_keyword_index`

#### **Before**

```python
@property
def get_keyword_index(self):
    # compute and return keyword_index
```

#### **After**

```python
from functools import cached_property

@cached_property
def get_keyword_index(self):
    # compute and return keyword_index
```

#### **Why This Is Better**

* **Performance**: `get_keyword_index` is called many times. Using `@cached_property` ensures the value is computed **only once** per instance and then cached, avoiding repeated computations.
* **Cleaner Code**: Consumers of `get_keyword_index` can use it like a normal attribute while benefiting from caching.

#### **Important Note**

* This change requires **Python 3.8 or higher**.
* Python 3.7 reached **end-of-life on June 27, 2023**, and no longer receives official support or security updates.


