### PR TITLE
Avoid Except blocks for performance

### DIFF
--- a/vietnam_number/word2number/hundreds.py
+++ b/vietnam_number/word2number/hundreds.py
@@ -51,10 +51,7 @@ def process_hundreds(words: list) -> str:
     if hundreds_index:
         value_of_hundreds = clean_words_number[:1]
 
-        try:
-            value_of_tens = clean_words_number[hundreds_index + 1 :]
-        except IndexError:
-            value_of_tens = []
+        value_of_tens = clean_words_number[hundreds_index + 1 :]
 
         # Trường hợp ['bốn', 'trăm', 'hai'] == 420
         if len(value_of_tens) == 1:
@@ -62,10 +59,7 @@ def process_hundreds(words: list) -> str:
 
     elif tens_index:
         # Lấy giá trị của phần chục.
-        try:
-            value_of_tens = clean_words_number[tens_index - 1 : tens_index + 2]
-        except IndexError:
-            value_of_tens = clean_words_number[tens_index - 1 :]
+        value_of_tens = clean_words_number[tens_index - 1 : tens_index + 2]
 
         # Lấy giá trị của phần còn lại.
         remaining = clean_words_number[tens_index + 2 :]

--- a/vietnam_number/word2number/tens.py
+++ b/vietnam_number/word2number/tens.py
@@ -47,17 +47,17 @@ def process_tens(words: list) -> str:
 
     if tens_index == 0:
         value_of_tens = 'một'
-        try:
-            value_of_units = clean_words_number[1]
-        except IndexError:
-            value_of_units = 'không'
+
+        value_of_units = (
+            clean_words_number[1] if len(clean_words_number) > 1 else "không"
+        )
 
     if tens_index == 1:
         value_of_tens = clean_words_number[0]
-        try:
-            value_of_units = clean_words_number[2]
-        except IndexError:
-            value_of_units = 'không'
+
+        value_of_units = (
+            clean_words_number[2] if len(clean_words_number) > 2 else "không"
+        )
 
     if tens_index is None:
         value_of_tens = clean_words_number[0]


### PR DESCRIPTION
#### Summary

Remove try-except blocks

#### Changes

1. **Accessing `value_of_units`**
   **Before:**

   ```python
   try:
       value_of_units = clean_words_number[1]
   except IndexError:
       value_of_units = 'không'
   ```

   **After:**

   ```python
   value_of_units = clean_words_number[1] if len(clean_words_number) > 1 else "không"
   ```

   **Reason:**
   Using `try-except` for normal index checking is more expensive than using a simple `if` condition. The new approach avoids unnecessary exception handling and is more readable.

2. **Accessing `value_of_tens` via slicing**
   **Before:**

   ```python
   try:
       value_of_tens = clean_words_number[tens_index - 1 : tens_index + 2]
   except IndexError:
       value_of_tens = clean_words_number[tens_index - 1 :] # this line is never reach
   ```

   **After:**

   ```python
   value_of_tens = clean_words_number[tens_index - 1 : tens_index + 2]
   ```

   **Reason:**
   List slicing in Python naturally handles out-of-range indices without raising `IndexError`. When the start or end index is out of range, the slice returns an empty list `[]` rather than raising an exception. This behavior is documented in the official Python docs: [Sequence Types — list, tuple, range](https://docs.python.org/3/library/stdtypes.html#typesseq), Note 4:

   > "The slice of `s` from `i` to `j` is defined as the sequence of items with index `k` such that `i <= k < j`. If `i` or `j` is greater than `len(s)`, use `len(s)`. If `i` is omitted or `None`, use `0`. If `j` is omitted or `None`, use `len(s)`. If `i` is greater than or equal to `j`, the slice is empty."

   Using slicing directly simplifies the code and removes redundant exception handling.

#### Benefits

* **Performance improvement:** Avoids the overhead of exception handling in normal code paths.
* **Readability:** Code is cleaner and easier to understand.

