### PR TITLE
Use in for check inexistence

### DIFF
--- a/vietnam_number/word2number/large_number.py
+++ b/vietnam_number/word2number/large_number.py
@@ -121,12 +121,10 @@ def process_large_number(words: list):
         if words[idx - 1] in hundreds_words:
             words[idx] = 'không'
 
-    try:
-        words.index('lẽ')
-    except ValueError:
+    if "lẽ" not in words:
         return process_large_number_normal(words)
-
-    return process_large_number_special(words)
+    else:
+        return process_large_number_special(words)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description:**
Refactor code to use `in` operator instead of `list.index` when checking for element absence.

**Change:**

```python
# Before
try:
    words.index('lẽ')
except ValueError:
    return process_large_number_normal(words)
return process_large_number_special(words)

# After
if "lẽ" not in words:
    return process_large_number_normal(words)
else:
    return process_large_number_special(words)
```
