### PR TITLE
Reduce branching and list accesses for better performance

### DIFF
--- a/vietnam_number/number2word/hundreds.py
+++ b/vietnam_number/number2word/hundreds.py
@@ -32,6 +32,21 @@ def n2w_hundreds(numbers: str):
     # tại vị trí index đầu tiên của 2 chuỗi điều có giá trị là 1
     # tuy nhiên, chuỗi đầu 1 là giá trị của hàng chục.
     # chuỗi cuối 1 là giá trị của hàng trăm.
+
+    # example for numbers = "123"
+    # numbers = "123"
+    #        |
+    #        v
+    # reversed_hundreds = "321"
+    #        |
+    #        v
+    # digit_position 0: "3" → "ba"  +   ""     → append → ["ba"]
+    # digit_position 1: "2" → "hai" + " mươi " → append → ["ba", "hai mươi "]
+    # digit_position 2: "1" → "một" + " trăm " → append → ["ba", "hai mươi ", "một trăm "]
+    #        |
+    #        v
+    # Reverse list for final output: ["một trăm ", "hai mươi ", "ba"]
+
     reversed_hundreds: str = numbers[:-4:-1]
 
     total_number = []

--- a/vietnam_number/number2word/hundreds.py
+++ b/vietnam_number/number2word/hundreds.py
@@ -32,7 +32,7 @@ def n2w_hundreds(numbers: str):
     # tại vị trí index đầu tiên của 2 chuỗi điều có giá trị là 1
     # tuy nhiên, chuỗi đầu 1 là giá trị của hàng chục.
     # chuỗi cuối 1 là giá trị của hàng trăm.
-    reversed_hundreds = numbers[::-1]
+    reversed_hundreds: str = numbers[:-4:-1]
 
     total_number = []
     for e in range(0, len(reversed_hundreds)):

--- a/vietnam_number/number2word/hundreds.py
+++ b/vietnam_number/number2word/hundreds.py
@@ -1,6 +1,13 @@
+from typing import Literal
+
 from vietnam_number.number2word.data import units
 from vietnam_number.number2word.units import n2w_units
 
+POSITION_UNITS: tuple[Literal[""], Literal[" mươi "], Literal[" trăm "]] = (
+    "",
+    " mươi ",
+    " trăm ",
+)
 
 def n2w_hundreds(numbers: str):
     """Hàm chuyển đổi số sang chữ số lớp trăm.
@@ -49,15 +56,10 @@ def n2w_hundreds(numbers: str):
 
     reversed_hundreds: str = numbers[:-4:-1]
 
-    total_number = []
-    for e in range(0, len(reversed_hundreds)):
-
-        if e == 0:
-            total_number.append(units[reversed_hundreds[e]])
-        elif e == 1:
-            total_number.append(units[reversed_hundreds[e]] + ' mươi ')
-        elif e == 2:
-            total_number.append(units[reversed_hundreds[e]] + ' trăm ')
+    total_number = [
+        units[digit_character] + POSITION_UNITS[digit_position]
+        for digit_position, digit_character in enumerate(reversed_hundreds)
+    ]
 
     # vd: ta có total_number = ['không', 'hai mươi ', 'một trăm ']
     # có nghĩa là ta muốn kết quả cuối cùng là: ['một trăm ', 'hai mươi ', 'không']


### PR DESCRIPTION
#### Summary

Refactored the logic for constructing digit-position labels (`trăm`, `mươi`, etc.) to be more concise, maintainable, and efficient.

#### Changes

* Introduced `POSITION_UNITS` tuple for centralized position-to-suffix mapping.
* Replaced iterative `append` logic with a list comprehension.
* Simplified `reversed_hundreds` using a Python slice.

#### Explanation of `reversed_hundreds`

* **Old approach:** Relied on accessing `reversed_hundreds` within a loop and handling positions manually.
* **New approach:** `reversed_hundreds = numbers[:-4:-1]`

  * Slice `[start:stop:step]` → `start` omitted (from end), `stop = -4` (stop before 4th char from end), `step = -1` (reverse order).
  * Effect: directly extracts the last three digits in reverse order (units → tens → hundreds).

This removes manual index handling and makes the intent clearer.

#### Benefits

* **Maintainability:** Centralized suffix definitions and digit extraction logic.
* **Readability:** Slice + comprehension makes digit-to-suffix mapping explicit.
* **Performance:**

  * Fewer list/tuple accesses overall.
  * No repeated `append` calls.
  * Less branching if else.
