### PR TITLE
Update GitHub Actions workflow to use supported Python versions 3.13

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Vietnam Number Toolkit
 .. image:: https://img.shields.io/pypi/v/vietnam-number
         :target: https://pypi.python.org/pypi/vietnam-number
 
-.. image:: https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue
+.. image:: https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue
         :target: https://pypi.python.org/pypi/vietnam-number
 
 .. image:: https://img.shields.io/badge/license-GPLv3-brightgreen.svg


### PR DESCRIPTION
**Description:**
This PR updates the Python versions in the GitHub Actions workflow to remove unsupported versions (3.5 and 3.6) and include currently supported versions (3.8–3.13).

**Changes made:**

* Updated the workflow matrix from `[3.5, 3.6, 3.7, 3.8]` to `[3.8, 3.9, 3.10, 3.11, 3.12, 3.13]`.
* No other workflow steps were changed.

**Why:**
Python 3.5 and 3.6 are no longer available on GitHub-hosted runners. Attempting to use them caused the following error:

```
Run actions/setup-python@v2
Version 3.6 was not found in the local cache
Error: Version 3.6 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

Updating to supported versions resolves this CI failure and ensures compatibility with currently maintained Python releases.

**Testing:**

* The workflow matrix now successfully sets up Python 3.8–3.12 on `ubuntu-latest`.
