### PR TITLE
Fix `str.replace` for Python 3.8+ compatibility

### DIFF
--- a/vietnam_number/number2word/__init__.py
+++ b/vietnam_number/number2word/__init__.py
@@ -13,7 +13,7 @@ def n2w(number: str):
 def n2w_single(number: str):
     # Xữ lý đặc thù dành cho số điện thoại
     if number.startswith("+84"):
-        number = number.replace("+84", "0", count=1)
+        number = number.replace("+84", "0", 1)
 
     # Tiền xữ lý dữ liệu chuỗi số đầu vào
     clean_number = pre_process_n2w(number)


### PR DESCRIPTION
**Description:**
Replaced `number.replace("+84", "0", count=1)` with `number.replace("+84", "0", 1)` to ensure compatibility with Python 3.8 and above.
The `count` keyword is only supported in Python 3.13+, so this change preserves functionality while supporting older Python versions.
