### PR TITLE
Fix bug: Safer input validation when input is not string

### DIFF
--- a/vietnam_number/word2number/__init__.py
+++ b/vietnam_number/word2number/__init__.py
@@ -15,11 +15,14 @@ def w2n(number_sentence):
 
     """
     # Kiểm tra tính hợp lệ của đầu vào
-    if isinstance(number_sentence, int) or number_sentence.isdigit():
+    if isinstance(number_sentence, int):
         return number_sentence
 
     if not isinstance(number_sentence, str):
         raise ValueError('Đầu vào không phải là dạng chuỗi (str)! Vui lòng truyền vào chuỗi các chữ số.')
+
+    if number_sentence.isdigit():
+        return number_sentence
 
     # Tiền xữ lý dữ liệu chuỗi số đầu vào
     clean_numbers = pre_process_w2n(number_sentence)
@@ -38,11 +41,14 @@ def w2n_single(number_sentence):
 
     """
     # Kiểm tra tính hợp lệ của đầu vào
-    if isinstance(number_sentence, int) or number_sentence.isdigit():
+    if isinstance(number_sentence, int):
         return number_sentence
 
     if not isinstance(number_sentence, str):
         raise ValueError('Đầu vào không phải là dạng chuỗi (str)! Vui lòng truyền vào chuỗi các chữ số.')
+
+    if number_sentence.isdigit():
+        return number_sentence
 
     # Tiền xữ lý dữ liệu chuỗi số đầu vào
     clean_numbers = pre_process_w2n(number_sentence)
@@ -61,11 +67,14 @@ def w2n_couple(number_sentence):
 
     """
     # Kiểm tra tính hợp lệ của đầu vào
-    if isinstance(number_sentence, int) or number_sentence.isdigit():
+    if isinstance(number_sentence, int):
         return number_sentence
 
     if not isinstance(number_sentence, str):
         raise ValueError('Đầu vào không phải là dạng chuỗi (str)! Vui lòng truyền vào chuỗi các chữ số.')
+
+    if number_sentence.isdigit():
+        return number_sentence
 
     # Tiền xữ lý dữ liệu chuỗi số đầu vào
     clean_numbers = pre_process_w2n(number_sentence)


### PR DESCRIPTION
**Summary:**
Refactor input validation to avoid calling `.isdigit()` on non-string objects and ensure all error checks are reachable.

**Old code (causes error / unreachable):**

```python
number_sentence = None  # None is part of Any type
if isinstance(number_sentence, int) or number_sentence.isdigit():
    return number_sentence

if not isinstance(number_sentence, str):
    raise ValueError('Đầu vào không phải là dạng chuỗi (str)! Vui lòng truyền vào chuỗi các chữ số.')
```

**Issues:**

* Calling `str.isdigit()` on non-strings raises `AttributeError`.
* The `ValueError` line is **never reached** because the previous condition already raise error.

**New code:**

```python
if isinstance(number_sentence, int):
    return number_sentence

if not isinstance(number_sentence, str):
    raise ValueError('Đầu vào không phải là dạng chuỗi (str)! Vui lòng truyền vào chuỗi các chữ số.')

if number_sentence.isdigit():
    return number_sentence
```

**Benefit:**

* **Safer and correct:** `.isdigit()` is only called on strings.
* **All checks reachable:** `ValueError` is now correctly raised for invalid non-string inputs.
