### PR TITLE
Use `frozenset.isdisjoint()` to check for presence of `word_multiplier`

### DIFF
--- a/vietnam_number/word2number/single.py
+++ b/vietnam_number/word2number/single.py
@@ -18,11 +18,12 @@ def pre_process_single(words: list):
         ValueError: Nếu chữ số đầu vào có từ liên kết.
 
     """
-    for word in words:
-        if word in word_multiplier:
-            raise ValueError('Chữ số đầu vào có từ liên kết. Vui lòng sử dụng hàm dành riêng cho chữ số có từ liên kết.')
-
-    return words
+    if word_multiplier.isdisjoint(words):
+        return words
+    else:
+        raise ValueError(
+            "Chữ số đầu vào có từ liên kết. Vui lòng sử dụng hàm dành riêng cho chữ số có từ liên kết."
+        )
 
 
 def process_single(words: list) -> str:


### PR DESCRIPTION
**Summary:**
Refactor the loop that checks for `word_multiplier` in `words` to a more efficient set operation using `frozenset.isdisjoint()`.

**Before:**

```python
for word in words:
    if word in word_multiplier:
        raise ValueError('Chữ số đầu vào có từ liên kết. Vui lòng sử dụng hàm dành riêng cho chữ số có từ liên kết.')

return words
```

**After:**

```python
if word_multiplier.isdisjoint(words):
    return words
else:
    raise ValueError(
        "Chữ số đầu vào có từ liên kết. Vui lòng sử dụng hàm dành riêng cho chữ số có từ liên kết."
    )
```

**Benefits:**


* **Cleaner and more readable:** Reduces multiple `if` checks to a single condition.
