### PR TITLE
Refactor word-splitting logic using `itertools.groupby` for clarity and performance

### DIFF
--- a/vietnam_number/word2number/large_number.py
+++ b/vietnam_number/word2number/large_number.py
@@ -1,3 +1,5 @@
+from itertools import groupby
+
 from vietnam_number.word2number.data import hundreds_words, special_word
 from vietnam_number.word2number.hundreds import process_hundreds
 from vietnam_number.word2number.utils.large_number import LargeNumber
@@ -96,19 +98,19 @@ def process_large_number_normal(words: list):
 
 
 def process_large_number_special(words: list):
-    size = len(words)
-
-    idx_list = [i for i, value in enumerate(words) if value in special_word]
-    number_list = (
-        words[i + 1 : j]
-        for i, j in zip(
-            [-1] + idx_list, idx_list + ([size] if idx_list[-1] != size else [])
-        )
-    )
-
+    #   Create sublists of consecutive words that are NOT in `special_word`.
+    #   The special word(s) act as split points and are NOT included in the output.
+    #
+    #   Example:
+    #   Input:  ['một', 'trăm', 'lẻ', 'ba'], special_word = {'lẻ'}
+    #   Output: [['một', 'trăm'], ['ba']]
     total_number = 0
-    for element in number_list:
-        total_number += int(process_large_number_normal(element))
+
+    for is_special_word, word_group in groupby(
+        words, key=lambda word: word in special_word
+    ):
+        if not is_special_word:
+            total_number += int(process_large_number_normal(list(word_group)))
 
     return total_number
 


### PR DESCRIPTION
**Summary:**
Refactor the logic for splitting `words` by `special_word` to simplify and clarify the code. The new approach uses Python’s `itertools.groupby` to group consecutive words that are **not** in `special_word`, rather than manually computing index slices.

**Changes:**

* **Old Approach:**

  * Manually created `idx_list` of positions where `words` are in `special_word`.
  * Generated `number_list` using list slicing and `zip`.
  * Iterated over `number_list` and summed processed numbers.
* **New Approach:**

  * Uses `itertools.groupby` to split `words` into sublists of consecutive words **not in** `special_word`.
  * Special words act as split points and are automatically excluded.
  * Directly processes each sublist and accumulates the total.

**Why This Is Better:**

1. **Simpler and More Readable:**

   * Eliminates manual index calculations and slicing, making the code easier to understand at a glance.
   * The `groupby` approach naturally expresses the intent: group words by whether they are special or not.

2. **Fewer Edge Cases:**

   * The old code had complex logic to handle the first and last slices (e.g., `[-1] + idx_list` and conditional handling for the last index).
   * `groupby` automatically handles consecutive sequences without extra index manipulation.

3. **Functional Clarity:**

   * The code now clearly separates “splitting words” from “processing numbers,” improving readability and maintainability.

4. **Performance Advantage:**

   * `itertools.groupby` is implemented in C internally, making it highly efficient for grouping compared to manual Python loops and slicing.
