### PR TITLE
Fix missing `units` import from merge conflict

### DIFF
--- a/vietnam_number/word2number/utils/base.py
+++ b/vietnam_number/word2number/utils/base.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 
 from vietnam_number.word2number.data import (
+    units,
     ALLOW_WORDS,
     billion_words,
     hundreds_words,


### PR DESCRIPTION
**Summary:**
Fix missing `units` import caused by previous merge conflict.

**Impact:**
Ensures `if word in units:` works correctly.