### PR TITLE
Minor change: Refactor code for developer clarity

### DIFF
--- a/vietnam_number/number2word/data.py
+++ b/vietnam_number/number2word/data.py
@@ -1,4 +1,4 @@
-units = {
+UNITS = {
     '0': 'không',
     '1': 'một',
     '2': 'hai',

--- a/vietnam_number/number2word/hundreds.py
+++ b/vietnam_number/number2word/hundreds.py
@@ -1,7 +1,6 @@
 from typing import Literal
 
 from vietnam_number.number2word.data import units
-from vietnam_number.number2word.units import n2w_units
 
 POSITION_UNITS: tuple[Literal[""], Literal[" mươi "], Literal[" trăm "]] = (
     "",
@@ -27,11 +26,16 @@ def n2w_hundreds(numbers: str):
         ValueError: Nếu số đầu vào là chuỗi rỗng.
 
     """
-    if len(numbers) > 3 or len(numbers) == 0:
-        raise ValueError('Số vượt quá giá trị của hàng trăm!')
+    # Optimal order: highest frequency first
+    numbers_length = len(numbers)
+    if numbers_length == 3 or numbers_length == 2:
+        pass
 
-    if len(numbers) == 1:
-        return n2w_units(numbers)
+    elif numbers_length == 1:
+        return units[numbers]
+
+    else:
+        raise ValueError("Số vượt quá giá trị của hàng trăm!")
 
     # Chúng ta cần duyệt danh sách từ phải qua trái nhằm phân biệt các giá trị từ nhỏ đến lớn.
     # Lý giải: giả sử chúng ta có 2 đầu vào: '10' và '123'

--- a/vietnam_number/number2word/hundreds.py
+++ b/vietnam_number/number2word/hundreds.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from vietnam_number.number2word.data import units
+from vietnam_number.number2word.data import UNITS
 
 POSITION_UNITS: tuple[Literal[""], Literal[" mươi "], Literal[" trăm "]] = (
     "",
@@ -32,7 +32,7 @@ def n2w_hundreds(numbers: str):
         pass
 
     elif numbers_length == 1:
-        return units[numbers]
+        return UNITS[numbers]
 
     else:
         raise ValueError("Số vượt quá giá trị của hàng trăm!")
@@ -60,7 +60,7 @@ def n2w_hundreds(numbers: str):
     reversed_hundreds: str = numbers[:-4:-1]
 
     total_number = (
-        units[digit_character] + POSITION_UNITS[digit_position]
+        UNITS[digit_character] + POSITION_UNITS[digit_position]
         for digit_position, digit_character in enumerate(reversed_hundreds)
     )
 

--- a/vietnam_number/number2word/single.py
+++ b/vietnam_number/number2word/single.py
@@ -1,4 +1,4 @@
-from vietnam_number.number2word.data import units
+from vietnam_number.number2word.data import UNITS
 
 
 def process_n2w_single(numbers: str):
@@ -10,7 +10,7 @@ def process_n2w_single(numbers: str):
     Returns:
         Chuỗi chữ số đầu ra.
     """
-    return " ".join(units[element] for element in numbers)
+    return " ".join(UNITS[element] for element in numbers)
 
 
 if __name__ == '__main__':

--- a/vietnam_number/number2word/units.py
+++ b/vietnam_number/number2word/units.py
@@ -1,4 +1,4 @@
-from vietnam_number.number2word.data import units
+from vietnam_number.number2word.data import UNITS
 
 
 def n2w_units(numbers: str):
@@ -16,7 +16,7 @@ def n2w_units(numbers: str):
 
     """
     if len(numbers) == 1:
-        return units[numbers]
+        return UNITS[numbers]
 
     elif not numbers:
         raise ValueError('Số rỗng!! vui lòng nhập số đúng định dạng!')

--- a/vietnam_number/number2word/units.py
+++ b/vietnam_number/number2word/units.py
@@ -15,14 +15,15 @@ def n2w_units(numbers: str):
         ValueError: Số đầu vào có giá trị lớn hơn 9.
 
     """
+    if len(numbers) == 1:
+        return units[numbers]
 
-    if not numbers:
+    elif not numbers:
         raise ValueError('Số rỗng!! vui lòng nhập số đúng định dạng!')
 
-    if len(numbers) > 1:
+    else:
         raise ValueError('Số vượt quá giá trị của hàng đơn vị!')
 
-    return units[numbers]
 
 
 if __name__ == '__main__':

--- a/vietnam_number/number2word/utils/base.py
+++ b/vietnam_number/number2word/utils/base.py
@@ -1,4 +1,4 @@
-from vietnam_number.number2word.data import units
+from vietnam_number.number2word.data import UNITS
 
 CHAR_TO_REMOVE = {
     " ": None,
@@ -42,7 +42,7 @@ def pre_process_n2w(number: str):
         raise ValueError('Đầu vào không phải là kiểu chuỗi chỉ chứa các ký tự số (isdigit)!')
 
     # xóa các ký tự số không có trong unit
-    clean_number = "".join(element for element in number if element in units)
+    clean_number = "".join(element for element in number if element in UNITS)
 
     # Thông báo lỗi nếu người dùng nhập đầu vào không hợp lệ!
     if not clean_number:

--- a/vietnam_number/word2number/couple.py
+++ b/vietnam_number/word2number/couple.py
@@ -1,6 +1,6 @@
 from itertools import zip_longest
 
-from vietnam_number.word2number.data import tens_words
+from vietnam_number.word2number.data import TENS_WORDS
 from vietnam_number.word2number.single import process_single
 from vietnam_number.word2number.tens import process_tens
 
@@ -22,11 +22,11 @@ def pre_process_couple(words: list):
 
     """
     # Trường hợp từ 'mươi' nằm ở cuối cùng.
-    if words[-1] in tens_words:
+    if words[-1] in TENS_WORDS:
         words.append('không')
 
     # Trường hợp từ 'mươi' nằm ở đầu.
-    if words[0] in tens_words:
+    if words[0] in TENS_WORDS:
         raise ValueError("Từ 'mươi' không thể đặt ở vị trí đầu tiên. Vui lòng nhập dãy chữ số đúng định dạng!")
 
     return words
@@ -45,7 +45,7 @@ def process_couple(words: list) -> str:
     clean_number = pre_process_couple(words)
 
     # Lấy tất cả vị trí index của 'mươi'
-    all_tens_index = [i for i, value in enumerate(clean_number) if value in tens_words]
+    all_tens_index = [i for i, value in enumerate(clean_number) if value in TENS_WORDS]
 
     if not all_tens_index:
         return process_single(clean_number)

--- a/vietnam_number/word2number/data.py
+++ b/vietnam_number/word2number/data.py
@@ -1,4 +1,4 @@
-units = {
+UNITS = {
     'không': 0,
     'một': 1,
     'mốt': 1,
@@ -17,24 +17,24 @@ units = {
     'chín': 9,
 }
 
-billion_words = frozenset(("tỷ", "tỏi", "tỉ"))
-million_words = frozenset(("triệu", "củ", "chai"))
-thousand_words = frozenset(("nghìn", "nghàn", "ngàn", "cành"))
+BILLION_WORDS = frozenset(("tỷ", "tỏi", "tỉ"))
+MILLION_WORDS = frozenset(("triệu", "củ", "chai"))
+THOUSAND_WORDS = frozenset(("nghìn", "nghàn", "ngàn", "cành"))
 
-BILLION_MILLION_THOUSAND_WORDS = billion_words.union(million_words, thousand_words)
+BILLION_MILLION_THOUSAND_WORDS = BILLION_WORDS.union(MILLION_WORDS, THOUSAND_WORDS)
 
-hundreds_words = frozenset(("trăm", "lít", "lốp", "xị"))
-tens_words = frozenset(("mươi", "chục"))
+HUNDREDS_WORDS = frozenset(("trăm", "lít", "lốp", "xị"))
+TENS_WORDS = frozenset(("mươi", "chục"))
 
-HUNDREDS_TENS_WORDS = hundreds_words.union(tens_words)
+HUNDREDS_TENS_WORDS = HUNDREDS_WORDS.union(TENS_WORDS)
 
-tens_special = ("mười",)
-special_word = frozenset(("lẽ", "linh", "lẻ"))
+TENS_SPECIAL = ("mười",)
+SPECIAL_WORDS = frozenset(("lẽ", "linh", "lẻ"))
 
-word_multiplier = BILLION_MILLION_THOUSAND_WORDS.union(
+WORD_MULTIPLIER = BILLION_MILLION_THOUSAND_WORDS.union(
     HUNDREDS_TENS_WORDS,
-    tens_special,
-    special_word,
+    TENS_SPECIAL,
+    SPECIAL_WORDS,
 )
 
-ALLOW_WORDS = word_multiplier.union(units)
+ALLOW_WORDS = WORD_MULTIPLIER.union(UNITS)

--- a/vietnam_number/word2number/hundreds.py
+++ b/vietnam_number/word2number/hundreds.py
@@ -78,6 +78,8 @@ def process_hundreds(words: list) -> str:
             # Trường hợp đặc biệt như ['ba', 'bốn', 'mươi', 'hai'] == 342
             elif tens_index == 2:
                 return process_units(remaining) + process_tens(value_of_tens)
+            else:
+                raise ValueError("Định dạng chữ số không hợp lệ.")
 
     # Trường hợp ['hai', 'ba'] == 023
     elif clean_words_number_count <= 2:

--- a/vietnam_number/word2number/hundreds.py
+++ b/vietnam_number/word2number/hundreds.py
@@ -90,7 +90,7 @@ def process_hundreds(words: list) -> str:
         value_of_tens = clean_words_number[1:]
 
     else:
-        value_of_hundreds = []
+        value_of_hundreds = ()
         value_of_tens = []
 
     return process_units(value_of_hundreds) + process_tens(value_of_tens)

--- a/vietnam_number/word2number/large_number.py
+++ b/vietnam_number/word2number/large_number.py
@@ -1,6 +1,6 @@
 from itertools import groupby
 
-from vietnam_number.word2number.data import hundreds_words, special_word
+from vietnam_number.word2number.data import HUNDREDS_WORDS, SPECIAL_WORDS
 from vietnam_number.word2number.hundreds import process_hundreds
 from vietnam_number.word2number.utils.large_number import LargeNumber
 
@@ -89,7 +89,7 @@ def process_large_number_special(words: list):
     total_number = 0
 
     for is_special_word, word_group in groupby(
-        words, key=lambda word: word in special_word
+        words, key=lambda word: word in SPECIAL_WORDS
     ):
         if not is_special_word:
             total_number += int(process_large_number_normal(list(word_group)))
@@ -103,9 +103,9 @@ def process_large_number(words: list):
     contain_special_word = False
 
     for index, value in enumerate(words):
-        if value in special_word:
+        if value in SPECIAL_WORDS:
             contain_special_word = True
-            if words[index - 1] in hundreds_words:
+            if words[index - 1] in HUNDREDS_WORDS:
                 words[index] = "không"
 
     if contain_special_word:

--- a/vietnam_number/word2number/single.py
+++ b/vietnam_number/word2number/single.py
@@ -1,4 +1,4 @@
-from vietnam_number.word2number.data import word_multiplier
+from vietnam_number.word2number.data import WORD_MULTIPLIER
 from vietnam_number.word2number.units import process_units
 
 
@@ -18,7 +18,7 @@ def pre_process_single(words: list):
         ValueError: Nếu chữ số đầu vào có từ liên kết.
 
     """
-    if word_multiplier.isdisjoint(words):
+    if WORD_MULTIPLIER.isdisjoint(words):
         return words
     else:
         raise ValueError(

--- a/vietnam_number/word2number/units.py
+++ b/vietnam_number/word2number/units.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 
-from vietnam_number.word2number.data import units
+from vietnam_number.word2number.data import UNITS
 
 
 def process_units(words: Sequence[str]) -> str:
@@ -19,7 +19,7 @@ def process_units(words: Sequence[str]) -> str:
     # nếu list truyền vào là rỗng thì bằng 0
     # Optimal order: highest frequency first
     if len(words) == 1:
-        return str(units[words[0]])
+        return str(UNITS[words[0]])
     elif not words:
         return "0"
     else:

--- a/vietnam_number/word2number/utils/base.py
+++ b/vietnam_number/word2number/utils/base.py
@@ -3,14 +3,14 @@ from functools import cached_property
 
 from vietnam_number.word2number.data import (
     ALLOW_WORDS,
-    billion_words,
-    hundreds_words,
-    million_words,
-    special_word,
-    tens_special,
-    tens_words,
-    thousand_words,
-    units,
+    BILLION_WORDS,
+    HUNDREDS_WORDS,
+    MILLION_WORDS,
+    SPECIAL_WORDS,
+    TENS_SPECIAL,
+    TENS_WORDS,
+    THOUSAND_WORDS,
+    UNITS,
 )
 
 KEYWORD_INDEX_TEMPLATE = {
@@ -47,25 +47,25 @@ class Numbers(object):
 
         for index_position, word in enumerate(self.words_number):
             # Optimal order: highest frequency first
-            if word in units:
+            if word in UNITS:
                 pass
 
-            elif word in tens_words:
+            elif word in TENS_WORDS:
                 keyword_index["tens_index"] = index_position
 
-            elif word in hundreds_words:
+            elif word in HUNDREDS_WORDS:
                 keyword_index["hundreds_index"] = index_position
 
-            elif word in thousand_words:
+            elif word in THOUSAND_WORDS:
                 keyword_index["thousand_index"] = index_position
 
-            elif word in million_words:
+            elif word in MILLION_WORDS:
                 keyword_index["million_index"] = index_position
 
-            elif word in billion_words:
+            elif word in BILLION_WORDS:
                 keyword_index["billion_index"] = index_position
 
-            elif word in special_word:
+            elif word in SPECIAL_WORDS:
                 keyword_index["special_index"] = index_position
 
         return keyword_index
@@ -82,7 +82,7 @@ def convert_to_tens_word(words: list[str]) -> list[str]:
     # Chuyển các từ mười, chục thành ['một,'mươi']
     new_words = []
     for word in words:
-        if word in tens_special:
+        if word in TENS_SPECIAL:
             new_words.append("một")
             new_words.append("mươi")
         elif word in ALLOW_WORDS:

--- a/vietnam_number/word2number/utils/base.py
+++ b/vietnam_number/word2number/utils/base.py
@@ -108,10 +108,11 @@ def pre_process_w2n(words: str):
         ValueError: Nếu đầu vào là chuỗi rỗng.
 
     """
-    words = words.replace('-', ' ')  # replace ký tự đặt biệt "-" sang khoản trắng
-    words = words.lower()  # converting chuổi đầu vào thành chuổi viết thường
-
-    split_words = words.strip().split()  # xóa khoảng trắng thừa và chia câu thành các từ
+    split_words = (
+        words.replace("-", " ")  # replace ký tự đặt biệt "-" sang khoản trắng
+        .lower()  # converting chuổi đầu vào thành chuổi viết thường
+        .split()  # xóa khoảng trắng thừa và chia câu thành các từ
+    )
 
     # Chuyển các từ 'mười', 'chục' thành cụm ['một,'mươi']
     clean_numbers = convert_to_tens_word(split_words)

--- a/vietnam_number/word2number/utils/large_number.py
+++ b/vietnam_number/word2number/utils/large_number.py
@@ -1,9 +1,9 @@
 from vietnam_number.word2number.data import (
     BILLION_MILLION_THOUSAND_WORDS,
-    billion_words,
-    million_words,
-    thousand_words,
-    units,
+    BILLION_WORDS,
+    MILLION_WORDS,
+    THOUSAND_WORDS,
+    UNITS,
 )
 from vietnam_number.word2number.utils.base import Numbers
 
@@ -35,7 +35,7 @@ class LargeNumber(Numbers):
         # Nếu danh sách chữ số truyền vào có 1 chữ số thuộc hàng đơn vị
         # thì thêm 'không' vào đầu của list
         # vd: ['hai'] => ['không', 'hai']
-        elif len(number_for_format) == 1 and number_for_format[0] in units:
+        elif len(number_for_format) == 1 and number_for_format[0] in UNITS:
             number_for_format.insert(0, 'không')
             return cls(number_for_format)
 
@@ -44,18 +44,18 @@ class LargeNumber(Numbers):
             number_for_format.insert(0, 'một')
 
         # Trường hợp văn nói "một triệu hai", "tỷ ba"
-        if number_for_format[-1] in units:
+        if number_for_format[-1] in UNITS:
             second_last_word = number_for_format[-2]
 
-            if second_last_word in billion_words:
+            if second_last_word in BILLION_WORDS:
                 number_for_format.append('trăm')
                 number_for_format.append('triệu')
 
-            elif second_last_word in million_words:
+            elif second_last_word in MILLION_WORDS:
                 number_for_format.append('trăm')
                 number_for_format.append('nghìn')
 
-            elif second_last_word in thousand_words:
+            elif second_last_word in THOUSAND_WORDS:
                 number_for_format.append('trăm')
 
         return cls(number_for_format)

--- a/vietnam_number/word2number/utils/tens.py
+++ b/vietnam_number/word2number/utils/tens.py
@@ -1,4 +1,4 @@
-from vietnam_number.word2number.data import tens_words, units
+from vietnam_number.word2number.data import TENS_WORDS, UNITS
 from vietnam_number.word2number.utils.base import Numbers
 
 
@@ -24,7 +24,7 @@ class NumbersOfTens(Numbers):
             pass
 
         # Trường hợp đầu vào chỉ có 1 số thuộc hàng đơn vị
-        elif len(number_for_format) == 1 and number_for_format[0] in units:
+        elif len(number_for_format) == 1 and number_for_format[0] in UNITS:
             number_for_format.insert(0, "không")
 
         # Trường hợp đầu vào là rỗng thì đầu ra là 00
@@ -43,7 +43,7 @@ class NumbersOfTens(Numbers):
 
         """
         words_number_counter = self.words_number_counter
-        for word in tens_words:
+        for word in TENS_WORDS:
             if words_number_counter[word] > 1:
                 raise ValueError(
                     f"Có nhiều hơn một từ {word} dùng để liên kết hàng chục!"


### PR DESCRIPTION
### **Summary**

This pull request refactors code, and fixes potential runtime errors.
   * **Impact:** Minor change for developer clarity; does **not require a new version/release**.
### **Changes**

1. **Simplified splitting of words**

   * Changed:

     ```python
     split_words = words.strip().split()
     ```

     to

     ```python
     split_words = words.split()
     ```
   * **Why:** `split()` without arguments already ignores leading/trailing whitespace and splits on any whitespace sequence, making `strip()` redundant.
   * **Benefit:** Cleaner, more concise, performance.
  
   **Example:**

   ```python
   >>> '   1   2   3   '.split()
   ['1', '2', '3']
   ```
 > If `sep` is not specified or is `None`, a different splitting algorithm is applied: runs of consecutive whitespace are regarded as a single separator, and the result will contain no empty strings at the start or end if the string has leading or trailing whitespace.

   * **Reference:** [Python `str.split()` documentation](https://docs.python.org/3/library/stdtypes.html#str.split)


2. **Converted constants to uppercase**

   * **Why:** This follows Python conventions (PEP 8) for constants, making the code more consistent and self-documenting.

3. **Adjusted hundreds value initialization**

   * Changed `value_of_hundreds = []` to `value_of_hundreds = ()`.
   * **Why:** Using a tuple makes the variable immutable, signaling that its value will not change later.

4. **Improved input length checking**

   * Replaced the previous logic that called `n2w_units(numbers)` for single-digit numbers with direct use of the `UNITS` mapping:

     ```python
     numbers_length = len(numbers)
     if numbers_length == 3 or numbers_length == 2:
         pass

     elif numbers_length == 1:
         return UNITS[numbers]

     else:
         raise ValueError("Số vượt quá giá trị của hàng trăm!")
     ```
   * **Why:** The `n2w_units` function was only used once and is no longer necessary at the moments, simplifying the code.

5. **Added explicit error handling for invalid digit formats**

   * Added:

     ```python
     else:
         raise ValueError("Định dạng chữ số không hợp lệ.")
     ```
   * **Why:** Fixes a potential `UnboundLocalError`  for `value_of_hundreds` when encountering unexpected formats.

