### PR TITLE
Remove redundant empty `list` check and add test for future-proofing

### DIFF
--- a/tests/word2number/test_large_number.py
+++ b/tests/word2number/test_large_number.py
@@ -2,6 +2,7 @@ import pytest
 
 from vietnam_number.word2number import w2n
 from vietnam_number.word2number.large_number import process_large_number
+from vietnam_number.word2number.utils.base import pre_process_w2n
 
 
 @pytest.mark.parametrize(
@@ -32,7 +33,6 @@ def test_w2n_large_number(word_number, number_result):
 @pytest.mark.parametrize(
     'word_number, number_result',
     [
-        ([], 0),
         (['một', 'triệu', 'bốn', 'nghìn', 'ba', 'mươi', 'hai'], 1004032),
         (['một', 'trăm', 'hai', 'triệu', 'bốn', 'nghìn', 'ba', 'mươi', 'hai'], 120004032),
         (['bốn', 'nghìn', 'ba', 'mươi', 'hai'], 4032),
@@ -73,3 +73,12 @@ def test_process_large_number(word_number, number_result):
 
     """
     assert process_large_number(word_number) == number_result
+
+
+def test_pre_process_w2n_empty_list_raises_error():
+    # Input that should produce an empty list from convert_to_tens_word
+    invalid_input = "abc"  # a string that is not recognized as a number word
+
+    # Expect ValueError to be raised
+    with pytest.raises(ValueError, match="không có chữ số hợp lệ"):
+        pre_process_w2n(invalid_input)

--- a/vietnam_number/word2number/utils/base.py
+++ b/vietnam_number/word2number/utils/base.py
@@ -119,6 +119,6 @@ def pre_process_w2n(words: str):
 
     # Thông báo lỗi nếu người dùng nhập đầu vào không hợp lệ!
     if not clean_numbers:
-        raise ValueError('không có chử số hợp lệ! vui lòng nhập chữ số hợp lệ.')
+        raise ValueError("không có chữ số hợp lệ! vui lòng nhập chữ số hợp lệ.")
 
     return clean_numbers

--- a/vietnam_number/word2number/utils/large_number.py
+++ b/vietnam_number/word2number/utils/large_number.py
@@ -26,16 +26,10 @@ class LargeNumber(Numbers):
             đã được định dạng lại.
 
         """
-        # Nếu list truyền vào là rỗng thì bằng 000000
-        if not number_for_format:
-            number_for_format.append("không")
-            number_for_format.append("không")
-            return cls(number_for_format)
-
         # Nếu danh sách chữ số truyền vào có 1 chữ số thuộc hàng đơn vị
         # thì thêm 'không' vào đầu của list
         # vd: ['hai'] => ['không', 'hai']
-        elif len(number_for_format) == 1 and number_for_format[0] in UNITS:
+        if len(number_for_format) == 1 and number_for_format[0] in UNITS:
             number_for_format.insert(0, 'không')
             return cls(number_for_format)
 


### PR DESCRIPTION
**Summary:**
This PR removes the redundant empty list check in number processing logic, as it is no longer necessary due to recent changes in preprocessing and grouping logic. A new test is added to ensure that invalid input is properly handled in the future.

**Details:**

1. **Old behavior:**
   The code explicitly checked if `number_for_format` was empty and appended `"không"` twice to handle empty input:

   ```python
   if not number_for_format:
       number_for_format.append("không")
       number_for_format.append("không")
       return cls(number_for_format)
   ```

2. **New behavior:**

   * The introduction of `itertools.groupby` in b3f8028f79098edf925d46af7f07b64fb42df660  ensures that the list of words (`words`) is never empty when passed to `process_large_number_normal`.

   ```python
   for is_special_word, word_group in groupby(words, key=lambda word: word in SPECIAL_WORDS):
       if not is_special_word:
           total_number += int(process_large_number_normal(list(word_group)))
   ```

   * `pre_process_w2n` raises a `ValueError` for empty input lists, ensuring invalid inputs are handled consistently:

   ```python
   if not clean_numbers:
       raise ValueError("không có chữ số hợp lệ! vui lòng nhập chữ số hợp lệ.")
   ```

3. **Test added for future-proofing:**

   ```python
   def test_pre_process_w2n_empty_list_raises_error():
       invalid_input = "abc"  # input that produces an empty list
       with pytest.raises(ValueError, match="không có chữ số hợp lệ"):
           pre_process_w2n(invalid_input)
   ```

   * Guarantees that future changes to `convert_to_tens_word` or preprocessing logic will continue to raise an error for invalid input instead of silently passing.

**Reasoning:**
With the new preprocessing and grouping logic, the empty list check is unnecessary. The added test ensures this behavior is maintained in future changes.
