### PR TITLE
Fix Regression bug: Unpacking errors for 2-digit inputs of  `n2w_hundreds`

### DIFF
--- a/tests/number2word/test_hundreds.py
+++ b/tests/number2word/test_hundreds.py
@@ -6,13 +6,17 @@ from vietnam_number.number2word.hundreds import n2w_hundreds
 @pytest.mark.parametrize(
     'number_hundreds, words_result',
     [
-        ('111', 'một trăm mười một'),
-        ('200', 'hai trăm'),
-        ('101', 'một trăm lẽ một'),
-        ('121', 'một trăm hai mươi mốt'),
-        ('815', 'tám trăm mười lăm'),
-        ('805', 'tám trăm lẽ năm'),
-        ('825', 'tám trăm hai mươi lăm'),
+        ("1", "một"),
+        ("11", "mười một"),
+        ("111", "một trăm mười một"),
+        ("215", "hai trăm mười lăm"),
+        ("221", "hai trăm hai mươi mốt"),
+        ("200", "hai trăm"),
+        ("101", "một trăm lẽ một"),
+        ("121", "một trăm hai mươi mốt"),
+        ("815", "tám trăm mười lăm"),
+        ("805", "tám trăm lẽ năm"),
+        ("825", "tám trăm hai mươi lăm"),
     ],
 )
 def test_n2w_hundreds(number_hundreds, words_result):

--- a/tests/number2word/test_large_number.py
+++ b/tests/number2word/test_large_number.py
@@ -6,6 +6,24 @@ from vietnam_number.number2word import n2w_large_number
 @pytest.mark.parametrize(
     "number_large_number, words_result",
     [
+        ("1", "một"),
+        ("12", "mười hai"),
+        ("123", "một trăm hai mươi ba"),
+        (str(1_234), "một nghìn hai trăm ba mươi bốn"),
+        (str(12_345), "mười hai nghìn ba trăm bốn mươi lăm"),
+        (str(1_234_567), "một triệu hai trăm ba mươi bốn nghìn năm trăm sáu mươi bảy"),
+        (
+            str(12_345_678),
+            "mười hai triệu ba trăm bốn mươi lăm nghìn sáu trăm bảy mươi tám",
+        ),
+        (
+            str(123_456_789),
+            "một trăm hai mươi ba triệu bốn trăm năm mươi sáu nghìn bảy trăm tám mươi chín",
+        ),
+        (
+            str(1_234_567_890),
+            "một tỷ hai trăm ba mươi bốn triệu năm trăm sáu mươi bảy nghìn tám trăm chín mươi",
+        ),
         (
             "115205201211",
             "một trăm mười lăm tỷ hai trăm lẽ năm triệu hai trăm lẽ một nghìn hai trăm mười một",

--- a/vietnam_number/number2word/hundreds.py
+++ b/vietnam_number/number2word/hundreds.py
@@ -26,16 +26,9 @@ def n2w_hundreds(numbers: str):
         ValueError: Nếu số đầu vào là chuỗi rỗng.
 
     """
-    # Optimal order: highest frequency first
     numbers_length = len(numbers)
-    if numbers_length == 3 or numbers_length == 2:
-        pass
-
-    elif numbers_length == 1:
+    if numbers_length == 1:
         return UNITS[numbers]
-
-    else:
-        raise ValueError("Số vượt quá giá trị của hàng trăm!")
 
     # Chúng ta cần duyệt danh sách từ phải qua trái nhằm phân biệt các giá trị từ nhỏ đến lớn.
     # Lý giải: giả sử chúng ta có 2 đầu vào: '10' và '123'

--- a/vietnam_number/number2word/hundreds.py
+++ b/vietnam_number/number2word/hundreds.py
@@ -75,7 +75,11 @@ def n2w_hundreds(numbers: str):
     #       6. 'hai trăm ba mươi năm' trở thành 'hai trăm ba mươi lăm'
 
     # Separate digits
-    digit_unit, digit_tens, digits_hundred = total_number
+    if numbers_length == 3:
+        digit_unit, digit_tens, digits_hundred = total_number
+    else:
+        digit_unit, digit_tens = total_number
+        digits_hundred = ""
 
     # Adjust tens
     if digit_tens == "không mươi ":


### PR DESCRIPTION
This PR resolves an error caused by incorrect list unpacking of `total_number`.

#### **Issue**

The previous code always tried to unpack three values:

```python
digit_unit, digit_tens, digits_hundred = total_number
```

This caused a `ValueError` when `total_number` only contained two elements, leading to a regression.

#### **Fix**

We now safely unpack based on the number of digits:

```python
if numbers_length == 3:
    digit_unit, digit_tens, digits_hundred = total_number
else:
    digit_unit, digit_tens = total_number
    digits_hundred = ""
```

#### **Outcome**

* Prevents unpacking errors for 2-digit inputs